### PR TITLE
Bugfix/unit test should fail travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "start": "node index.js",
   "scripts": {
-    "test": "nyc node_modules/.bin/_mocha; ./node_modules/.bin/eslint .;",
+    "test": "nyc node_modules/.bin/_mocha && ./node_modules/.bin/eslint .",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls;"
   },
   "repository": {

--- a/test/test-mysql-queries.js
+++ b/test/test-mysql-queries.js
@@ -102,7 +102,7 @@ WHERE table_schema LIKE 'dummy_schema'
 
 const twoTypeJunctionQueryWithoutFilter = `SELECT ke.TABLE_NAME
 FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
-LEFT JOIN COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
 WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
 /* it's not a constraint if there are no referenced table */
 AND ke.REFERENCED_TABLE_NAME IS NOT NULL
@@ -116,13 +116,13 @@ HAVING COUNT(ke.TABLE_NAME) = 2;`;
 
 const twoTypeJunctionQueryWithFilter = `SELECT ke.TABLE_NAME
 FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
-LEFT JOIN COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
 WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
 /* it's not a constraint if there are no referenced table */
 AND ke.REFERENCED_TABLE_NAME IS NOT NULL
 /* only junction tables */
 AND col.COLUMN_KEY = 'PRI'
-AND tab.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table')
+AND ke.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table')
 /* junction tables appear once per referenced table */
 GROUP BY ke.TABLE_NAME
 /* only want junction between two tables */
@@ -149,36 +149,36 @@ const dummyTables = mysql.escape(['table_1', 'table_2', 'last_table']);
 
 describe('./lib/mysql/queries.js', function () {
     describe('liquibase query', function () {
-        it('works as intended', function () {
-            assert.strictEqual(liquibaseQuery, queries.liquibase(dummySchema));
+        it('returns the expected query', function () {
+            assert.strictEqual(queries.liquibase(dummySchema), liquibaseQuery);
         });
     });
     describe('jhipster query', function () {
-        it('works as intended', function () {
-            assert.strictEqual(jhipsterQuery, queries.jhipster(dummySchema));
+        it('returns the expected query', function () {
+            assert.strictEqual(queries.jhipster(dummySchema), jhipsterQuery);
         });
     });
     describe('manyToMany query', function () {
-        it('works as intended', function () {
-            assert.strictEqual(manyToManyQuery, queries.manyToMany(dummySchema));
+        it('returns the expected query', function () {
+            assert.strictEqual(queries.manyToMany(dummySchema), manyToManyQuery);
         });
     });
     describe('manyToOne query', function () {
-        it('works as intended', function () {
-            assert.strictEqual(manyToOneQuery, queries.manyToOne(dummySchema));
+        it('returns the expected query', function () {
+            assert.strictEqual(queries.manyToOne(dummySchema), manyToOneQuery);
         });
     });
     describe('oneToOne query', function () {
-        it('works as intended', function () {
-            assert.strictEqual(oneToOneQuery, queries.oneToOne(dummySchema));
+        it('returns the expected query', function () {
+            assert.strictEqual(queries.oneToOne(dummySchema), oneToOneQuery);
         });
     });
     describe('columns query', function () {
-        it('works as intended with tables to filter', function () {
-            assert.strictEqual(columnsQuery, queries.columns(dummySchema, dummyTables));
+        it('returns query that only retrieves the given tables', function () {
+            assert.strictEqual(queries.columns(dummySchema, dummyTables), columnsQuery);
         });
-        it('works as intended with no tables to filter', function () {
-            assert.strictEqual(columnsQueryWhenNoTables, queries.columns(dummySchema, ''));
+        it('returns query that doesn\'t exclude more tables', function () {
+            assert.strictEqual(queries.columns(dummySchema, ''), columnsQueryWhenNoTables);
         });
         it('throws with parameters that aren\'t strings', function () {
             assert.throws(() => queries.columns(['dummy_schema'], null), TypeError);
@@ -186,23 +186,23 @@ describe('./lib/mysql/queries.js', function () {
         });
     });
     describe('twoTypeJunction query', function () {
-        it('works as intended with tables to filter', function () {
-            assert.strictEqual(twoTypeJunctionQueryWithFilter, queries.twoTypeJunction(dummySchema, dummyFilter));
+        it('returns query that excludes tables according to their TABLE_NAME', function () {
+            assert.strictEqual(queries.twoTypeJunction(dummySchema, dummyFilter), twoTypeJunctionQueryWithFilter);
         });
-        it('works as intended with no tables to filter', function () {
-            assert.strictEqual(twoTypeJunctionQueryWithoutFilter, queries.twoTypeJunction(dummySchema, ''));
+        it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
+            assert.strictEqual(queries.twoTypeJunction(dummySchema, ''), twoTypeJunctionQueryWithoutFilter);
         });
         it('throws with parameters that aren\'t strings', function () {
-            assert.throws(() => queries.twoTypeJunction(['dummy_schema'], null), TypeError);
-            assert.throws(() => queries.twoTypeJunction(dummySchema, null), TypeError);
+            assert.throws(() => queries.twoTypeJunction(['dummy_schema'], null), TypeError); // 1st param throws error
+            assert.throws(() => queries.twoTypeJunction(dummySchema, null), TypeError); // 2nd param throws error
         });
     });
     describe('tables query', function () {
-        it('works as intended with tables to filter', function () {
-            assert.strictEqual(tablesQueryWithFilter, queries.tables(dummySchema, dummyFilter));
+        it('returns query that excludes tables according to their TABLE_NAME', function () {
+            assert.strictEqual(queries.tables(dummySchema, dummyFilter), tablesQueryWithFilter);
         });
-        it('works as intended with no tables to filter', function () {
-            assert.strictEqual(tablesQueryWithoutFilter, queries.tables(dummySchema, ''));
+        it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
+            assert.strictEqual(queries.tables(dummySchema, ''), tablesQueryWithoutFilter);
         });
         it('throws with parameters that aren\'t strings', function () {
             assert.throws(() => queries.tables(['dummy_schema'], null), TypeError);

--- a/test/test-mysql-queries.js
+++ b/test/test-mysql-queries.js
@@ -147,63 +147,76 @@ const dummySchema = mysql.escape('dummy_schema');
 const dummyFilter = mysql.escape(['filtered_table_1', 'filtered_table_2', 'last_filtered_table']);
 const dummyTables = mysql.escape(['table_1', 'table_2', 'last_table']);
 
-describe('./lib/mysql/queries.js', function () {
-    describe('liquibase query', function () {
+describe('lib/mysql/queries', function () {
+    describe('liquibase', function () {
         it('returns the expected query', function () {
             assert.strictEqual(queries.liquibase(dummySchema), liquibaseQuery);
         });
     });
-    describe('jhipster query', function () {
+
+    describe('jhipster', function () {
         it('returns the expected query', function () {
             assert.strictEqual(queries.jhipster(dummySchema), jhipsterQuery);
         });
     });
-    describe('manyToMany query', function () {
+
+    describe('manyToMany', function () {
         it('returns the expected query', function () {
             assert.strictEqual(queries.manyToMany(dummySchema), manyToManyQuery);
         });
     });
-    describe('manyToOne query', function () {
+
+    describe('manyToOne', function () {
         it('returns the expected query', function () {
             assert.strictEqual(queries.manyToOne(dummySchema), manyToOneQuery);
         });
     });
-    describe('oneToOne query', function () {
+
+    describe('oneToOne', function () {
         it('returns the expected query', function () {
             assert.strictEqual(queries.oneToOne(dummySchema), oneToOneQuery);
         });
     });
-    describe('columns query', function () {
+
+    describe('columns', function () {
         it('returns query that only retrieves the given tables', function () {
             assert.strictEqual(queries.columns(dummySchema, dummyTables), columnsQuery);
         });
+
         it('returns query that doesn\'t exclude more tables', function () {
             assert.strictEqual(queries.columns(dummySchema, ''), columnsQueryWhenNoTables);
         });
+
         it('throws with parameters that aren\'t strings', function () {
             assert.throws(() => queries.columns(['dummy_schema'], null), TypeError);
             assert.throws(() => queries.columns(dummySchema, null), TypeError);
         });
     });
-    describe('twoTypeJunction query', function () {
+
+    describe('twoTypeJunction', function () {
         it('returns query that excludes tables according to their TABLE_NAME', function () {
             assert.strictEqual(queries.twoTypeJunction(dummySchema, dummyFilter), twoTypeJunctionQueryWithFilter);
         });
+
         it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
             assert.strictEqual(queries.twoTypeJunction(dummySchema, ''), twoTypeJunctionQueryWithoutFilter);
         });
+
         it('throws with parameters that aren\'t strings', function () {
             assert.throws(() => queries.twoTypeJunction(['dummy_schema'], null), TypeError); // 1st param throws error
             assert.throws(() => queries.twoTypeJunction(dummySchema, null), TypeError); // 2nd param throws error
         });
     });
-    describe('tables query', function () {
+
+    describe('tables', function () {
         it('returns query that excludes tables according to their TABLE_NAME', function () {
             assert.strictEqual(queries.tables(dummySchema, dummyFilter), tablesQueryWithFilter);
         });
+
         it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
             assert.strictEqual(queries.tables(dummySchema, ''), tablesQueryWithoutFilter);
         });
+
         it('throws with parameters that aren\'t strings', function () {
             assert.throws(() => queries.tables(['dummy_schema'], null), TypeError);
             assert.throws(() => queries.tables(dummySchema, null), TypeError);


### PR DESCRIPTION
unit testing output was suppressed because it was chained with semicolon, using && (AND) operator fixes this and a failed unit test will correctly fail the build.