### PR TITLE
move long dummy objects to own file

### DIFF
--- a/test/templates/dummies.js
+++ b/test/templates/dummies.js
@@ -1,0 +1,247 @@
+const dummyEntities = {
+    authors: {
+        id: { ordinalPosition: 1, columnType: 'int(11)' },
+        name: { ordinalPosition: 2, columnType: 'varchar(255)' },
+        birth_date: { ordinalPosition: 3, columnType: 'date' }
+    },
+    books: {
+        id: { ordinalPosition: 1, columnType: 'int(11)' },
+        title: { ordinalPosition: 2, columnType: 'varchar(255)' },
+        price: { ordinalPosition: 3, columnType: 'bigint(20)' },
+        author: { ordinalPosition: 4, columnType: 'int(11)' }
+    }
+};
+
+
+const dummyQueryResults = [
+    {
+        table_name: 'authors',
+        column_name: 'id',
+        ordinal_position: 1,
+        column_type: 'int(11)'
+    }, {
+        table_name: 'authors',
+        column_name: 'name',
+        ordinal_position: 2,
+        column_type: 'varchar(255)'
+    }, {
+        table_name: 'authors',
+        column_name: 'birth_date',
+        ordinal_position: 3,
+        column_type: 'date'
+    }, {
+        table_name: 'books',
+        column_name: 'id',
+        ordinal_position: 1,
+        column_type: 'int(11)'
+    }, {
+        table_name: 'books',
+        column_name: 'title',
+        ordinal_position: 2,
+        column_type: 'varchar(255)'
+    }, {
+        table_name: 'books',
+        column_name: 'price',
+        ordinal_position: 3,
+        column_type: 'bigint(20)'
+    }, {
+        table_name: 'books',
+        column_name: 'author',
+        ordinal_position: 4,
+        column_type: 'int(11)'
+    }
+];
+
+
+// template choices, generated with dbi_book_author
+const expectedColumnsSelectionChoices = [
+    { type: 'separator', line: '\u001b[2mauthors\u001b[22m' },
+    { name: 'id (int(11))', value: 'authors.id', checked: true },
+    { name: 'name (varchar(255))', value: 'authors.name', checked: true },
+    { name: 'birth_date (date)', value: 'authors.birth_date', checked: true },
+    { type: 'separator', line: '\u001b[2mbooks\u001b[22m' },
+    { name: 'id (int(11))', value: 'books.id', checked: true },
+    { name: 'title (varchar(255))', value: 'books.title', checked: true },
+    { name: 'price (bigint(20))', value: 'books.price', checked: true },
+    { name: 'author (int(11))', value: 'books.author', checked: true }
+];
+
+
+const liquibaseQuery = `SELECT tab.TABLE_NAME
+FROM INFORMATION_SCHEMA.TABLES tab
+WHERE TABLE_SCHEMA = 'dummy_schema'
+AND tab.TABLE_NAME IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK');`;
+
+
+const jhipsterQuery = `SELECT tab.TABLE_NAME
+FROM INFORMATION_SCHEMA.TABLES tab
+WHERE TABLE_SCHEMA = 'dummy_schema'
+AND tab.TABLE_NAME LIKE 'jhi\\_%';`;
+
+
+const manyToManyQuery = `SELECT
+    ke.TABLE_NAME AS 'JUNCTION_TABLE',
+    GROUP_CONCAT(ke.COLUMN_NAME ORDER BY ke.REFERENCED_TABLE_NAME ASC) AS 'FOREIGN_KEYS',
+    GROUP_CONCAT(ke.REFERENCED_TABLE_NAME ORDER BY ke.REFERENCED_TABLE_NAME ASC) AS 'REFERENCED_TABLES'
+FROM KEY_COLUMN_USAGE ke
+
+    LEFT JOIN COLUMNS col
+        ON col.TABLE_NAME = ke.TABLE_NAME
+           AND col.COLUMN_NAME = ke.COLUMN_NAME
+           AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+
+WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
+    /* exclude JHipster Tables */
+    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
+    /* exclude liquibase tables */
+    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
+    /* only relationship constraints, this excludes indexes and alike */
+    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
+    /* only many-to-many relationships */
+    AND col.COLUMN_KEY = 'PRI'
+
+/* ensure we only get junction tables between two tables. */
+GROUP BY ke.TABLE_NAME
+HAVING COUNT(ke.TABLE_NAME) = 2;`;
+
+
+const manyToOneQuery = `SELECT
+    ke.TABLE_NAME as 'TABLE_FROM',
+    ke.COLUMN_NAME as 'COL_FROM',
+    ke.REFERENCED_TABLE_NAME as 'TABLE_TO'
+
+FROM KEY_COLUMN_USAGE ke
+
+    LEFT JOIN COLUMNS col
+        ON col.TABLE_NAME = ke.TABLE_NAME
+           AND col.COLUMN_NAME = ke.COLUMN_NAME
+           AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+
+WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
+    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
+    /* exclude liquibase tables */
+    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
+    /* only relationship constraints, this excludes indexes and alikes */
+    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
+    /* only many-to-many relationships */
+    AND col.COLUMN_KEY = 'MUL';`;
+
+
+const oneToOneQuery = `SELECT
+  ke.TABLE_NAME as 'TABLE_FROM',
+  ke.COLUMN_NAME as 'COL_FROM',
+  ke.REFERENCED_TABLE_NAME as 'TABLE_TO'
+
+FROM KEY_COLUMN_USAGE ke
+
+  LEFT JOIN COLUMNS col
+    ON col.TABLE_NAME = ke.TABLE_NAME
+       AND col.COLUMN_NAME = ke.COLUMN_NAME
+       AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+
+WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
+    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
+    /* exclude liquibase tables */
+    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
+    /* only relationship constraints, this excludes indexes and alikes */
+    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
+    /* only many-to-many relationships */
+    AND col.COLUMN_KEY = 'UNI';`;
+
+
+const columnsQuery = `SELECT table_schema, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, character_maximum_length, character_octet_length, numeric_precision, numeric_scale, datetime_precision
+FROM information_schema.columns
+WHERE table_schema LIKE 'dummy_schema'
+AND table_name IN ('table_1', 'table_2', 'last_table');`;
+
+
+const columnsQueryWhenNoTables = `SELECT table_schema, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, character_maximum_length, character_octet_length, numeric_precision, numeric_scale, datetime_precision
+FROM information_schema.columns
+WHERE table_schema LIKE 'dummy_schema'
+;`;
+
+
+const twoTypeJunctionQueryWithoutFilter = `SELECT ke.TABLE_NAME
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
+LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
+/* it's not a constraint if there are no referenced table */
+AND ke.REFERENCED_TABLE_NAME IS NOT NULL
+/* only junction tables */
+AND col.COLUMN_KEY = 'PRI'
+
+/* junction tables appear once per referenced table */
+GROUP BY ke.TABLE_NAME
+/* only want junction between two tables */
+HAVING COUNT(ke.TABLE_NAME) = 2;`;
+
+
+const twoTypeJunctionQueryWithFilter = `SELECT ke.TABLE_NAME
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
+LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
+WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
+/* it's not a constraint if there are no referenced table */
+AND ke.REFERENCED_TABLE_NAME IS NOT NULL
+/* only junction tables */
+AND col.COLUMN_KEY = 'PRI'
+AND ke.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table')
+/* junction tables appear once per referenced table */
+GROUP BY ke.TABLE_NAME
+/* only want junction between two tables */
+HAVING COUNT(ke.TABLE_NAME) = 2;`;
+
+
+const allColumnsQueryWithFilter = `SELECT
+col.table_name,
+col.column_name,
+col.ordinal_position,
+col.column_type
+FROM information_schema.columns col
+WHERE col.table_schema LIKE 'dummy_schema'
+AND col.table_name IN ('table_1', 'table_2', 'last_table');`;
+
+
+const allColumnsQueryWithoutFilter = `SELECT
+col.table_name,
+col.column_name,
+col.ordinal_position,
+col.column_type
+FROM information_schema.columns col
+WHERE col.table_schema LIKE 'dummy_schema'
+;`;
+
+
+const tablesQueryWithFilter = `SELECT tab.TABLE_NAME
+FROM INFORMATION_SCHEMA.TABLES tab
+WHERE TABLE_SCHEMA = 'dummy_schema'
+/* exclude views and alike */
+AND TABLE_TYPE LIKE 'BASE TABLE'
+AND tab.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table');`;
+
+
+const tablesQueryWithoutFilter = `SELECT tab.TABLE_NAME
+FROM INFORMATION_SCHEMA.TABLES tab
+WHERE TABLE_SCHEMA = 'dummy_schema'
+/* exclude views and alike */
+AND TABLE_TYPE LIKE 'BASE TABLE'
+;`;
+
+
+module.exports = {
+    dummyEntities,
+    dummyQueryResults,
+    expectedColumnsSelectionChoices,
+    liquibaseQuery,
+    jhipsterQuery,
+    manyToManyQuery,
+    manyToOneQuery,
+    oneToOneQuery,
+    columnsQuery,
+    columnsQueryWhenNoTables,
+    twoTypeJunctionQueryWithoutFilter,
+    twoTypeJunctionQueryWithFilter,
+    allColumnsQueryWithFilter,
+    allColumnsQueryWithoutFilter,
+    tablesQueryWithFilter,
+    tablesQueryWithoutFilter
+};

--- a/test/test-mysql-index.js
+++ b/test/test-mysql-index.js
@@ -7,64 +7,10 @@ const sinon = require('sinon');
 const mysql = require('mysql');
 
 const cst = require('../lib/mysql/constants');
+const dummies = require('./templates/dummies');
 const index = require('../lib/mysql/index');
 
 const sandbox = sinon.sandbox.create();
-
-const dummyQueryResults = [
-    {
-        table_name: 'authors',
-        column_name: 'id',
-        ordinal_position: 1,
-        column_type: 'int(11)'
-    }, {
-        table_name: 'authors',
-        column_name: 'name',
-        ordinal_position: 2,
-        column_type: 'varchar(255)'
-    }, {
-        table_name: 'authors',
-        column_name: 'birth_date',
-        ordinal_position: 3,
-        column_type: 'date'
-    }, {
-        table_name: 'books',
-        column_name: 'id',
-        ordinal_position: 1,
-        column_type: 'int(11)'
-    }, {
-        table_name: 'books',
-        column_name: 'title',
-        ordinal_position: 2,
-        column_type: 'varchar(255)'
-    }, {
-        table_name: 'books',
-        column_name: 'price',
-        ordinal_position: 3,
-        column_type: 'bigint(20)'
-    }, {
-        table_name: 'books',
-        column_name: 'author',
-        ordinal_position: 4,
-        column_type: 'int(11)'
-    }
-];
-
-const dummyTables = ['authors', 'books'];
-
-const dummyEntities = {
-    authors: {
-        id: { ordinalPosition: 1, columnType: 'int(11)' },
-        name: { ordinalPosition: 2, columnType: 'varchar(255)' },
-        birth_date: { ordinalPosition: 3, columnType: 'date' }
-    },
-    books: {
-        id: { ordinalPosition: 1, columnType: 'int(11)' },
-        title: { ordinalPosition: 2, columnType: 'varchar(255)' },
-        price: { ordinalPosition: 3, columnType: 'bigint(20)' },
-        author: { ordinalPosition: 4, columnType: 'int(11)' }
-    }
-};
 
 describe('lib/mysql/index', function () {
     afterEach(function () {
@@ -218,8 +164,10 @@ describe('lib/mysql/index', function () {
 
     describe('organizeColumns', function () {
         it('returns an organized object representing the database structure', function () {
+            const dummyQueryResults = dummies.dummyQueryResults;
+            const dummyTables = ['authors', 'books'];
             const actualResult = index.organizeColumns(dummyQueryResults, dummyTables);
-            const expectedResult = dummyEntities;
+            const expectedResult = dummies.dummyEntities;
 
             // first check we have the exact same number of tables, and the tables have the same name
             const actualResultTables = Object.keys(actualResult);
@@ -257,11 +205,12 @@ describe('lib/mysql/index', function () {
         };
 
         it('returns the correctly updated session object', function () {
+            const dummyQueryResults = dummies.dummyQueryResults;
             queryStub.onCall(0).callsArgWith(1, null, dummyQueryResults);
             return index.entityCandidatesColumns(dummySession)
                 .then((resolvedValue) => {
                     const actualResult = resolvedValue.entities;
-                    const expectedResult = dummyEntities;
+                    const expectedResult = dummies.dummyEntities;
 
                     // first check we have the exact same number of tables, and the tables have the same name
                     const actualResultTables = Object.keys(actualResult);

--- a/test/test-mysql-queries.js
+++ b/test/test-mysql-queries.js
@@ -5,207 +5,60 @@
 const assert = require('assert');
 const mysql = require('mysql');
 
+
+const dummies = require('./templates/dummies');
 const queries = require('../lib/mysql/queries');
-
-const liquibaseQuery = `SELECT tab.TABLE_NAME
-FROM INFORMATION_SCHEMA.TABLES tab
-WHERE TABLE_SCHEMA = 'dummy_schema'
-AND tab.TABLE_NAME IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK');`;
-
-
-const jhipsterQuery = `SELECT tab.TABLE_NAME
-FROM INFORMATION_SCHEMA.TABLES tab
-WHERE TABLE_SCHEMA = 'dummy_schema'
-AND tab.TABLE_NAME LIKE 'jhi\\_%';`;
-
-
-const manyToManyQuery = `SELECT
-    ke.TABLE_NAME AS 'JUNCTION_TABLE',
-    GROUP_CONCAT(ke.COLUMN_NAME ORDER BY ke.REFERENCED_TABLE_NAME ASC) AS 'FOREIGN_KEYS',
-    GROUP_CONCAT(ke.REFERENCED_TABLE_NAME ORDER BY ke.REFERENCED_TABLE_NAME ASC) AS 'REFERENCED_TABLES'
-FROM KEY_COLUMN_USAGE ke
-
-    LEFT JOIN COLUMNS col
-        ON col.TABLE_NAME = ke.TABLE_NAME
-           AND col.COLUMN_NAME = ke.COLUMN_NAME
-           AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
-
-WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
-    /* exclude JHipster Tables */
-    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
-    /* exclude liquibase tables */
-    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
-    /* only relationship constraints, this excludes indexes and alike */
-    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
-    /* only many-to-many relationships */
-    AND col.COLUMN_KEY = 'PRI'
-
-/* ensure we only get junction tables between two tables. */
-GROUP BY ke.TABLE_NAME
-HAVING COUNT(ke.TABLE_NAME) = 2;`;
-
-
-const manyToOneQuery = `SELECT
-    ke.TABLE_NAME as 'TABLE_FROM',
-    ke.COLUMN_NAME as 'COL_FROM',
-    ke.REFERENCED_TABLE_NAME as 'TABLE_TO'
-
-FROM KEY_COLUMN_USAGE ke
-
-    LEFT JOIN COLUMNS col
-        ON col.TABLE_NAME = ke.TABLE_NAME
-           AND col.COLUMN_NAME = ke.COLUMN_NAME
-           AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
-
-WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
-    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
-    /* exclude liquibase tables */
-    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
-    /* only relationship constraints, this excludes indexes and alikes */
-    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
-    /* only many-to-many relationships */
-    AND col.COLUMN_KEY = 'MUL';`;
-
-
-const oneToOneQuery = `SELECT
-  ke.TABLE_NAME as 'TABLE_FROM',
-  ke.COLUMN_NAME as 'COL_FROM',
-  ke.REFERENCED_TABLE_NAME as 'TABLE_TO'
-
-FROM KEY_COLUMN_USAGE ke
-
-  LEFT JOIN COLUMNS col
-    ON col.TABLE_NAME = ke.TABLE_NAME
-       AND col.COLUMN_NAME = ke.COLUMN_NAME
-       AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
-
-WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
-    AND ke.TABLE_NAME NOT LIKE 'jhi\\_%'
-    /* exclude liquibase tables */
-    AND ke.TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')
-    /* only relationship constraints, this excludes indexes and alikes */
-    AND ke.REFERENCED_TABLE_NAME IS NOT NULL
-    /* only many-to-many relationships */
-    AND col.COLUMN_KEY = 'UNI';`;
-
-
-const columnsQuery = `SELECT table_schema, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, character_maximum_length, character_octet_length, numeric_precision, numeric_scale, datetime_precision
-FROM information_schema.columns
-WHERE table_schema LIKE 'dummy_schema'
-AND table_name IN ('table_1', 'table_2', 'last_table');`;
-
-const columnsQueryWhenNoTables = `SELECT table_schema, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, character_maximum_length, character_octet_length, numeric_precision, numeric_scale, datetime_precision
-FROM information_schema.columns
-WHERE table_schema LIKE 'dummy_schema'
-;`;
-
-
-const twoTypeJunctionQueryWithoutFilter = `SELECT ke.TABLE_NAME
-FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
-LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
-WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
-/* it's not a constraint if there are no referenced table */
-AND ke.REFERENCED_TABLE_NAME IS NOT NULL
-/* only junction tables */
-AND col.COLUMN_KEY = 'PRI'
-
-/* junction tables appear once per referenced table */
-GROUP BY ke.TABLE_NAME
-/* only want junction between two tables */
-HAVING COUNT(ke.TABLE_NAME) = 2;`;
-
-const twoTypeJunctionQueryWithFilter = `SELECT ke.TABLE_NAME
-FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE ke
-LEFT JOIN INFORMATION_SCHEMA.COLUMNS col ON col.TABLE_NAME = ke.TABLE_NAME AND col.COLUMN_NAME = ke.COLUMN_NAME AND col.TABLE_SCHEMA = ke.TABLE_SCHEMA
-WHERE ke.REFERENCED_TABLE_SCHEMA = 'dummy_schema'
-/* it's not a constraint if there are no referenced table */
-AND ke.REFERENCED_TABLE_NAME IS NOT NULL
-/* only junction tables */
-AND col.COLUMN_KEY = 'PRI'
-AND ke.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table')
-/* junction tables appear once per referenced table */
-GROUP BY ke.TABLE_NAME
-/* only want junction between two tables */
-HAVING COUNT(ke.TABLE_NAME) = 2;`;
-
-
-const allColumnsQueryWithFilter = `SELECT
-col.table_name,
-col.column_name,
-col.ordinal_position,
-col.column_type
-FROM information_schema.columns col
-WHERE col.table_schema LIKE 'dummy_schema'
-AND col.table_name IN ('table_1', 'table_2', 'last_table');`;
-
-
-const allColumnsQueryWithoutFilter = `SELECT
-col.table_name,
-col.column_name,
-col.ordinal_position,
-col.column_type
-FROM information_schema.columns col
-WHERE col.table_schema LIKE 'dummy_schema'
-;`;
-
-
-const tablesQueryWithFilter = `SELECT tab.TABLE_NAME
-FROM INFORMATION_SCHEMA.TABLES tab
-WHERE TABLE_SCHEMA = 'dummy_schema'
-/* exclude views and alike */
-AND TABLE_TYPE LIKE 'BASE TABLE'
-AND tab.TABLE_NAME NOT IN ('filtered_table_1', 'filtered_table_2', 'last_filtered_table');`;
-
-
-const tablesQueryWithoutFilter = `SELECT tab.TABLE_NAME
-FROM INFORMATION_SCHEMA.TABLES tab
-WHERE TABLE_SCHEMA = 'dummy_schema'
-/* exclude views and alike */
-AND TABLE_TYPE LIKE 'BASE TABLE'
-;`;
 
 
 const dummySchema = mysql.escape('dummy_schema');
 const dummyFilter = mysql.escape(['filtered_table_1', 'filtered_table_2', 'last_filtered_table']);
 const dummyTables = mysql.escape(['table_1', 'table_2', 'last_table']);
 
+
 describe('lib/mysql/queries', function () {
     describe('liquibase', function () {
         it('returns the expected query', function () {
+            const liquibaseQuery = dummies.liquibaseQuery;
             assert.strictEqual(queries.liquibase(dummySchema), liquibaseQuery);
         });
     });
 
     describe('jhipster', function () {
         it('returns the expected query', function () {
+            const jhipsterQuery = dummies.jhipsterQuery;
             assert.strictEqual(queries.jhipster(dummySchema), jhipsterQuery);
         });
     });
 
     describe('manyToMany', function () {
         it('returns the expected query', function () {
+            const manyToManyQuery = dummies.manyToManyQuery;
             assert.strictEqual(queries.manyToMany(dummySchema), manyToManyQuery);
         });
     });
 
     describe('manyToOne', function () {
         it('returns the expected query', function () {
+            const manyToOneQuery = dummies.manyToOneQuery;
             assert.strictEqual(queries.manyToOne(dummySchema), manyToOneQuery);
         });
     });
 
     describe('oneToOne', function () {
         it('returns the expected query', function () {
+            const oneToOneQuery = dummies.oneToOneQuery;
             assert.strictEqual(queries.oneToOne(dummySchema), oneToOneQuery);
         });
     });
 
     describe('columns', function () {
         it('returns query that only retrieves the given tables', function () {
+            const columnsQuery = dummies.columnsQuery;
             assert.strictEqual(queries.columns(dummySchema, dummyTables), columnsQuery);
         });
 
         it('returns query that doesn\'t exclude more tables', function () {
+            const columnsQueryWhenNoTables = dummies.columnsQueryWhenNoTables;
             assert.strictEqual(queries.columns(dummySchema, ''), columnsQueryWhenNoTables);
         });
 
@@ -217,10 +70,12 @@ describe('lib/mysql/queries', function () {
 
     describe('allColumns', function () {
         it('returns query retrieving all the columns for the given tables', function () {
+            const allColumnsQueryWithFilter = dummies.allColumnsQueryWithFilter;
             assert.strictEqual(queries.allColumns(dummySchema, dummyTables), allColumnsQueryWithFilter);
         });
 
         it('returns query retrieving all columns without excluding tables', function () {
+            const allColumnsQueryWithoutFilter = dummies.allColumnsQueryWithoutFilter;
             assert.strictEqual(queries.allColumns(dummySchema, ''), allColumnsQueryWithoutFilter);
         });
 
@@ -233,10 +88,12 @@ describe('lib/mysql/queries', function () {
 
     describe('twoTypeJunction', function () {
         it('returns query that excludes tables according to their TABLE_NAME', function () {
+            const twoTypeJunctionQueryWithFilter = dummies.twoTypeJunctionQueryWithFilter;
             assert.strictEqual(queries.twoTypeJunction(dummySchema, dummyFilter), twoTypeJunctionQueryWithFilter);
         });
 
         it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
+            const twoTypeJunctionQueryWithoutFilter = dummies.twoTypeJunctionQueryWithoutFilter;
             assert.strictEqual(queries.twoTypeJunction(dummySchema, ''), twoTypeJunctionQueryWithoutFilter);
         });
 
@@ -248,10 +105,12 @@ describe('lib/mysql/queries', function () {
 
     describe('tables', function () {
         it('returns query that excludes tables according to their TABLE_NAME', function () {
+            const tablesQueryWithFilter = dummies.tablesQueryWithFilter;
             assert.strictEqual(queries.tables(dummySchema, dummyFilter), tablesQueryWithFilter);
         });
 
         it('returns query that doesn\'t that excludes tables according to their TABLE_NAME', function () {
+            const tablesQueryWithoutFilter = dummies.tablesQueryWithoutFilter;
             assert.strictEqual(queries.tables(dummySchema, ''), tablesQueryWithoutFilter);
         });
 

--- a/test/test-prompt.js
+++ b/test/test-prompt.js
@@ -11,6 +11,7 @@ const prompt = require('../prompt');
 const log = require('../lib/log');
 const cst = require('../constants');
 const db = require('../lib/db-commons');
+const dummies = require('./templates/dummies');
 
 const sandbox = sinon.sandbox.create();
 
@@ -272,17 +273,7 @@ describe('prompt', function () {
 
     describe('selectColumnsQuestionChoices', function () {
         // template choices, generated with dbi_book_author
-        const expectedChoices = [
-            { type: 'separator', line: '\u001b[2mauthors\u001b[22m' },
-            { name: 'id (int(11))', value: 'authors.id', checked: true },
-            { name: 'name (varchar(255))', value: 'authors.name', checked: true },
-            { name: 'birth_date (date)', value: 'authors.birth_date', checked: true },
-            { type: 'separator', line: '\u001b[2mbooks\u001b[22m' },
-            { name: 'id (int(11))', value: 'books.id', checked: true },
-            { name: 'title (varchar(255))', value: 'books.title', checked: true },
-            { name: 'price (bigint(20))', value: 'books.price', checked: true },
-            { name: 'author (int(11))', value: 'books.author', checked: true }
-        ];
+        const expectedChoices = dummies.expectedColumnsSelectionChoices;
 
         it('returns the expected choices', function () {
             const actualChoices = prompt.selectColumnsQuestionChoices(dummyEntities);


### PR DESCRIPTION
I moved long dummy object to a separate `dummies` file. We have less lines of code in our tests and I have removed global variables from them. I suggest we keep putting our dummies objects in that file (and structuring the file as it grows) in order to avoid cluttering the unit tests.